### PR TITLE
Fix generated index local imports for TypeScript

### DIFF
--- a/lib/index-generator.ts
+++ b/lib/index-generator.ts
@@ -36,7 +36,7 @@ export function generateMcpExportName(url: string): string {
 
 export function generateIndexFile(toolNames: string[], mcpUrl: string): string {
   const imports = toolNames
-    .map((name) => `import { ${name}ToolWithClient } from './${name}.js';`)
+    .map((name) => `import { ${name}ToolWithClient } from './${name}';`)
     .join("\n");
 
   const exportsWithDefaultClient = toolNames
@@ -52,7 +52,7 @@ export function generateIndexFile(toolNames: string[], mcpUrl: string): string {
 
   return `// Auto-generated index file for MCP tools
 // Source: ${mcpUrl}
-import { getMcpClient } from './client.js';
+import { getMcpClient } from './client';
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 ${imports}
 
@@ -68,7 +68,7 @@ ${exportsWithClient}
 // Individual tool exports
 ${toolNames
   .map(
-    (name) => `export const ${name}Tool = ${name}ToolWithClient(getMcpClient);`
+    (name) => `export const ${name}Tool = ${name}ToolWithClient(getMcpClient);`,
   )
   .join("\n")}
 `;

--- a/mcps/huggingface.co/mcp/index.ts
+++ b/mcps/huggingface.co/mcp/index.ts
@@ -1,16 +1,16 @@
 // Auto-generated index file for MCP tools
 // Source: https://huggingface.co/mcp
-import { getMcpClient } from "./client.js";
+import { getMcpClient } from "./client";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { hf_whoamiToolWithClient } from "./hf_whoami.js";
-import { space_searchToolWithClient } from "./space_search.js";
-import { model_searchToolWithClient } from "./model_search.js";
-import { model_detailsToolWithClient } from "./model_details.js";
-import { paper_searchToolWithClient } from "./paper_search.js";
-import { dataset_searchToolWithClient } from "./dataset_search.js";
-import { dataset_detailsToolWithClient } from "./dataset_details.js";
-import { hf_doc_searchToolWithClient } from "./hf_doc_search.js";
-import { gr1_flux1_schnell_inferToolWithClient } from "./gr1_flux1_schnell_infer.js";
+import { hf_whoamiToolWithClient } from "./hf_whoami";
+import { space_searchToolWithClient } from "./space_search";
+import { model_searchToolWithClient } from "./model_search";
+import { model_detailsToolWithClient } from "./model_details";
+import { paper_searchToolWithClient } from "./paper_search";
+import { dataset_searchToolWithClient } from "./dataset_search";
+import { dataset_detailsToolWithClient } from "./dataset_details";
+import { hf_doc_searchToolWithClient } from "./hf_doc_search";
+import { gr1_flux1_schnell_inferToolWithClient } from "./gr1_flux1_schnell_infer";
 
 // Exports using a default client
 export const mcpHuggingfaceTools = {

--- a/mcps/mcp.grep.app/index.ts
+++ b/mcps/mcp.grep.app/index.ts
@@ -1,8 +1,8 @@
 // Auto-generated index file for MCP tools
 // Source: https://mcp.grep.app
-import { getMcpClient } from "./client.js";
+import { getMcpClient } from "./client";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { searchGitHubToolWithClient } from "./searchGitHub.js";
+import { searchGitHubToolWithClient } from "./searchGitHub";
 
 // Exports using a default client
 export const mcpGrepTools = {

--- a/mcps/mcp.linear.app/sse/index.ts
+++ b/mcps/mcp.linear.app/sse/index.ts
@@ -1,30 +1,30 @@
 // Auto-generated index file for MCP tools
 // Source: https://mcp.linear.app/sse
-import { getMcpClient } from "./client.js";
+import { getMcpClient } from "./client";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { list_commentsToolWithClient } from "./list_comments.js";
-import { create_commentToolWithClient } from "./create_comment.js";
-import { list_cyclesToolWithClient } from "./list_cycles.js";
-import { get_documentToolWithClient } from "./get_document.js";
-import { list_documentsToolWithClient } from "./list_documents.js";
-import { get_issueToolWithClient } from "./get_issue.js";
-import { list_issuesToolWithClient } from "./list_issues.js";
-import { create_issueToolWithClient } from "./create_issue.js";
-import { update_issueToolWithClient } from "./update_issue.js";
-import { list_issue_statusesToolWithClient } from "./list_issue_statuses.js";
-import { get_issue_statusToolWithClient } from "./get_issue_status.js";
-import { list_issue_labelsToolWithClient } from "./list_issue_labels.js";
-import { create_issue_labelToolWithClient } from "./create_issue_label.js";
-import { list_projectsToolWithClient } from "./list_projects.js";
-import { get_projectToolWithClient } from "./get_project.js";
-import { create_projectToolWithClient } from "./create_project.js";
-import { update_projectToolWithClient } from "./update_project.js";
-import { list_project_labelsToolWithClient } from "./list_project_labels.js";
-import { list_teamsToolWithClient } from "./list_teams.js";
-import { get_teamToolWithClient } from "./get_team.js";
-import { list_usersToolWithClient } from "./list_users.js";
-import { get_userToolWithClient } from "./get_user.js";
-import { search_documentationToolWithClient } from "./search_documentation.js";
+import { list_commentsToolWithClient } from "./list_comments";
+import { create_commentToolWithClient } from "./create_comment";
+import { list_cyclesToolWithClient } from "./list_cycles";
+import { get_documentToolWithClient } from "./get_document";
+import { list_documentsToolWithClient } from "./list_documents";
+import { get_issueToolWithClient } from "./get_issue";
+import { list_issuesToolWithClient } from "./list_issues";
+import { create_issueToolWithClient } from "./create_issue";
+import { update_issueToolWithClient } from "./update_issue";
+import { list_issue_statusesToolWithClient } from "./list_issue_statuses";
+import { get_issue_statusToolWithClient } from "./get_issue_status";
+import { list_issue_labelsToolWithClient } from "./list_issue_labels";
+import { create_issue_labelToolWithClient } from "./create_issue_label";
+import { list_projectsToolWithClient } from "./list_projects";
+import { get_projectToolWithClient } from "./get_project";
+import { create_projectToolWithClient } from "./create_project";
+import { update_projectToolWithClient } from "./update_project";
+import { list_project_labelsToolWithClient } from "./list_project_labels";
+import { list_teamsToolWithClient } from "./list_teams";
+import { get_teamToolWithClient } from "./get_team";
+import { list_usersToolWithClient } from "./list_users";
+import { get_userToolWithClient } from "./get_user";
+import { search_documentationToolWithClient } from "./search_documentation";
 
 // Exports using a default client
 export const mcpLinearTools = {

--- a/mcps/mcp.notion.com/mcp/index.ts
+++ b/mcps/mcp.notion.com/mcp/index.ts
@@ -1,20 +1,20 @@
 // Auto-generated index file for MCP tools
 // Source: https://mcp.notion.com/mcp
-import { getMcpClient } from "./client.js";
+import { getMcpClient } from "./client";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { searchToolWithClient } from "./search.js";
-import { fetchToolWithClient } from "./fetch.js";
-import { notioncreatepagesToolWithClient } from "./notioncreatepages.js";
-import { notionupdatepageToolWithClient } from "./notionupdatepage.js";
-import { notionmovepagesToolWithClient } from "./notionmovepages.js";
-import { notionduplicatepageToolWithClient } from "./notionduplicatepage.js";
-import { notioncreatedatabaseToolWithClient } from "./notioncreatedatabase.js";
-import { notionupdatedatabaseToolWithClient } from "./notionupdatedatabase.js";
-import { notioncreatecommentToolWithClient } from "./notioncreatecomment.js";
-import { notiongetcommentsToolWithClient } from "./notiongetcomments.js";
-import { notiongetusersToolWithClient } from "./notiongetusers.js";
-import { notiongetselfToolWithClient } from "./notiongetself.js";
-import { notiongetuserToolWithClient } from "./notiongetuser.js";
+import { searchToolWithClient } from "./search";
+import { fetchToolWithClient } from "./fetch";
+import { notioncreatepagesToolWithClient } from "./notioncreatepages";
+import { notionupdatepageToolWithClient } from "./notionupdatepage";
+import { notionmovepagesToolWithClient } from "./notionmovepages";
+import { notionduplicatepageToolWithClient } from "./notionduplicatepage";
+import { notioncreatedatabaseToolWithClient } from "./notioncreatedatabase";
+import { notionupdatedatabaseToolWithClient } from "./notionupdatedatabase";
+import { notioncreatecommentToolWithClient } from "./notioncreatecomment";
+import { notiongetcommentsToolWithClient } from "./notiongetcomments";
+import { notiongetusersToolWithClient } from "./notiongetusers";
+import { notiongetselfToolWithClient } from "./notiongetself";
+import { notiongetuserToolWithClient } from "./notiongetuser";
 
 // Exports using a default client
 export const mcpNotionTools = {

--- a/mcps/mcp.vercel.com/index.ts
+++ b/mcps/mcp.vercel.com/index.ts
@@ -1,18 +1,18 @@
 // Auto-generated index file for MCP tools
 // Source: https://mcp.vercel.com
-import { getMcpClient } from "./client.js";
+import { getMcpClient } from "./client";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { search_vercel_documentationToolWithClient } from "./search_vercel_documentation.js";
-import { deploy_to_vercelToolWithClient } from "./deploy_to_vercel.js";
-import { list_projectsToolWithClient } from "./list_projects.js";
-import { get_projectToolWithClient } from "./get_project.js";
-import { list_deploymentsToolWithClient } from "./list_deployments.js";
-import { get_deploymentToolWithClient } from "./get_deployment.js";
-import { get_deployment_build_logsToolWithClient } from "./get_deployment_build_logs.js";
-import { get_access_to_vercel_urlToolWithClient } from "./get_access_to_vercel_url.js";
-import { web_fetch_vercel_urlToolWithClient } from "./web_fetch_vercel_url.js";
-import { list_teamsToolWithClient } from "./list_teams.js";
-import { check_domain_availability_and_priceToolWithClient } from "./check_domain_availability_and_price.js";
+import { search_vercel_documentationToolWithClient } from "./search_vercel_documentation";
+import { deploy_to_vercelToolWithClient } from "./deploy_to_vercel";
+import { list_projectsToolWithClient } from "./list_projects";
+import { get_projectToolWithClient } from "./get_project";
+import { list_deploymentsToolWithClient } from "./list_deployments";
+import { get_deploymentToolWithClient } from "./get_deployment";
+import { get_deployment_build_logsToolWithClient } from "./get_deployment_build_logs";
+import { get_access_to_vercel_urlToolWithClient } from "./get_access_to_vercel_url";
+import { web_fetch_vercel_urlToolWithClient } from "./web_fetch_vercel_url";
+import { list_teamsToolWithClient } from "./list_teams";
+import { check_domain_availability_and_priceToolWithClient } from "./check_domain_availability_and_price";
 
 // Exports using a default client
 export const mcpVercelTools = {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "dist/mcp-tools-cli.js",
     "sample": "tsx samples/grep-app-test.ts",
     "prepublishOnly": "npm run build",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "tsx --test tests/**/*.test.ts",
     "version-packages": "changeset version",
     "changeset": "changeset",
     "release": "pnpm build && changeset publish"

--- a/tests/index-generator.test.ts
+++ b/tests/index-generator.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { generateIndexFile } from "../lib/index-generator.js";
+
+test("generates extensionless imports for generated TypeScript siblings", () => {
+  const generated = generateIndexFile(
+    ["searchGitHub", "list_projects"],
+    "https://mcp.grep.app",
+  );
+
+  assert.ok(generated.includes("from './client';"));
+  assert.ok(generated.includes("from './searchGitHub';"));
+  assert.ok(generated.includes("from './list_projects';"));
+
+  assert.ok(!generated.includes("from './client.js';"));
+  assert.ok(!generated.includes("from './searchGitHub.js';"));
+  assert.ok(!generated.includes("from './list_projects.js';"));
+  assert.ok(
+    generated.includes("from '@modelcontextprotocol/sdk/client/index.js';"),
+  );
+});


### PR DESCRIPTION
## Summary

- emit extensionless local imports from generated `index.ts` files so Next dev can resolve the generated `.ts` sibling files
- refresh the checked-in generated MCP index samples
- add a regression test for generated local import specifiers while keeping package subpath `.js` imports intact

Fixes #8

## Validation

- `./node_modules/.bin/tsx --test tests/**/*.test.ts`
- `./node_modules/.bin/tsc --pretty false`

Note: I used local binaries because `pnpm test` and `pnpm build` did not reach the package scripts in my environment. Corepack selected pnpm 11 for this checkout, then pnpm aborted on the existing v6 lockfile/node_modules state before running scripts.
